### PR TITLE
DS-602 Fix the issue with the redirection to react.

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -41,7 +41,7 @@ export class AppConfig {
 }
 
 export const configuration: AppConfig = {
-  version: '3.9.0.0',
+  version: '3.9.0.1',
   name: environment.appName,
   tokenApp: environment.tokenName,
   tokenExpiryTime: 3,

--- a/src/app/explore/hat-application-details/hat-application-details.component.html
+++ b/src/app/explore/hat-application-details/hat-application-details.component.html
@@ -24,7 +24,7 @@
         <div class="app-details-header-headline">
           This app is rated {{app.application.info.rating.score}}
         </div>
-        <a href="https://www.hatcommunity.org/hat-dex-rating" target="_blank" class="app-link">Learn more</a>
+        <a href="https://resources.dataswift.io/contents/4a9f5153-7d52-4b79-8eb1-e570aa331291" target="_blank" class="app-link">Learn more</a>
       </ng-container>
 
       <a mat-button [ngClass]="['app-details-status', appStatus]"

--- a/src/app/explore/hat-applications.service.ts
+++ b/src/app/explore/hat-applications.service.ts
@@ -88,7 +88,8 @@ export class HatApplicationsService {
     const redirectUrl = setup.url || setup.iosUrl || '';
     const redirectRumpel = window.location.href.replace('#', '%23');
 
-    return `https://${this.hatUrl}/#/hatlogin?name=${id}&fallback=${redirectRumpel}&redirect=${redirectUrl}%3Fredirect=${redirectRumpel}`;
+    // tslint:disable-next-line:max-line-length
+    return `https://${this.hatUrl}/hatlogin?application_id=${id}&fallback=${redirectRumpel}&redirect_uri=${redirectUrl}%3Fredirect=${redirectRumpel}`;
   }
 
   getAppStatus(app: HatApplication): 'goto' | 'running' | 'fetching' | 'failing' | 'untouched' | 'update' {

--- a/src/app/hmi/hmi-shared-components/hmi-rating/hmi-rating.component.html
+++ b/src/app/hmi/hmi-shared-components/hmi-rating/hmi-rating.component.html
@@ -20,7 +20,7 @@
 
   <ng-container *ngIf="app.info.rating && app.info.rating.score">
     <p class="hmi-rating-section-text">This app is rated {{app.info.rating.score}}<br>
-      <a href="https://www.hatcommunity.org/hat-dex-rating" target="_blank" class="hmi-rating-section-text-link">Learn more</a>
+      <a href="https://resources.dataswift.io/contents/4a9f5153-7d52-4b79-8eb1-e570aa331291" target="_blank" class="hmi-rating-section-text-link">Learn more</a>
     </p>
   </ng-container>
 </section>

--- a/src/app/redirect.guard.ts
+++ b/src/app/redirect.guard.ts
@@ -9,7 +9,16 @@ export class RedirectGuard implements CanActivate {
   constructor(private router: Router) {}
 
   canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean {
-    window.location.href = window.location.href.replace('%23', '#').replace('/#', '');
+    const hash = window.location.hash;
+    let path = '';
+
+    if (hash.startsWith('#')) {
+      path = hash.substring(1);
+    } else if (hash.startsWith('%23')) {
+      path = hash.substring(3)
+    }
+
+    window.location.href =  window.location.origin + path;
 
     return false;
   }


### PR DESCRIPTION
- Fix the issue when redirect URL to the React Rumpel contains hashes.
- Add the new "learn more" rating URL.